### PR TITLE
Fix age calculations, test imports, and remove unused variable

### DIFF
--- a/make_people.py
+++ b/make_people.py
@@ -88,7 +88,7 @@ def create_person_entity(
         age=age,
         nationality=person_nationality, # Store the string used for Faker locale
         household=household_orm_obj, # Link to the Household ORM instance
-        household_UUID=household_orm_obj.household_UUID, # For potential direct FK reference
+
         is_claimant=False, # Default, can be updated later if needed
         # married_to_UUID is more complex and would require finding the spouse's ORM object or UUID
     )

--- a/people/age.py
+++ b/people/age.py
@@ -125,7 +125,7 @@ age_over18_names = [
     "87",
     "88",
     "89",
-    "90+",
+    "90",
 ]
 
 age_over18_weights = [
@@ -393,58 +393,39 @@ def age_over65() -> int:
     return return_age
 
 
-def year_of_birth(age: int) -> int:
+def fake_dob(age: int) -> object:
     import datetime
-
-    now = datetime.datetime.now()
-    year = now.year - age
-    return year
-
-
-def fake_dob(year_of_b: int) -> object:
-    old_leap_year = calendar.isleap(year_of_b)
-    birth = fake.date_of_birth()
-    if False == old_leap_year and birth.month == 2 and birth.day == 29:
-        birth = birth.replace(day=28)
-    birth = birth.replace(year=year_of_b)
-    return birth
-
+    from dateutil.relativedelta import relativedelta
+    now = datetime.date.today()
+    min_date = now - relativedelta(years=age+1) + relativedelta(days=1)
+    max_date = now - relativedelta(years=age)
+    return fake.date_between(start_date=min_date, end_date=max_date)
 
 def dob_over65():
     age = age_over65()
-    year = year_of_birth(age)
-    dob = fake_dob(year)
-    print(dob, age)
+    dob = fake_dob(age)
     return dob, age
 
 
 def dob_working_age():
     age = age_working_age()
-    year = year_of_birth(age)
-    dob = fake_dob(year)
-    print(dob, age)
+    dob = fake_dob(age)
     return dob, age
 
 
 def dob_under18():
     age = age_under18()
-    year = year_of_birth(age)
-    dob = fake_dob(year)
-    print(dob, age)
+    dob = fake_dob(age)
     return dob, age
 
 
 def dob_over18():
     age = age_over18()
-    year = year_of_birth(age)
-    dob = fake_dob(year)
-    print(dob, age)
+    dob = fake_dob(age)
     return dob, age
 
 
 def dob_non_dep():
     age = age_non_dep()
-    year = year_of_birth(age)
-    dob = fake_dob(year)
-    print(dob, age)
+    dob = fake_dob(age)
     return dob, age

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -4,7 +4,7 @@ import collections # For checking list contents if needed
 
 # Functions/modules to test
 from people import age as people_age
-from household import household as household_module # household is a function and a module name
+import household as household_module # household is a function and a module name
 from people import nationality as people_nationality
 
 def calculate_age_for_test(born: date) -> int:


### PR DESCRIPTION
This pull request addresses several issues in the codebase:
1. **Age Calculations (`people/age.py`)**: Replaced flawed `year_of_birth` calculation that simply swapped years. The new implementation correctly determines bounds using `dateutil.relativedelta` to consistently produce birth dates matching the intended age today.
2. **Invalid Age String**: Corrected `"90+"` to `"90"` in `people/age.py` to prevent `ValueError` parsing errors during integer conversion.
3. **Redundant Field (`make_people.py`)**: Removed `household_UUID` assignment in `create_person_entity` as the object mapping handles the relationship directly.
4. **Test Imports (`tests/test_core_helpers.py`)**: Fixed an incorrect import `from household import household` which incorrectly shadowed the module.
5. **Print Statements**: Removed leftover development print statements from the date generation functions.

---
*PR created automatically by Jules for task [17514328080126243090](https://jules.google.com/task/17514328080126243090) started by @chrisstorey*